### PR TITLE
Added type restriction support for DBpedia Spotlight

### DIFF
--- a/pikes-twm/src/main/java/eu/fbk/dkm/pikes/twm/DBpediaSpotlightAnnotate.java
+++ b/pikes-twm/src/main/java/eu/fbk/dkm/pikes/twm/DBpediaSpotlightAnnotate.java
@@ -9,7 +9,7 @@ public class DBpediaSpotlightAnnotate extends Linking {
     private static String LABEL = "dbpedia-annotate";
     private String confidence;
     private String allowedTypes;
-    private static final String DBPS_ADDRESS = "http://spotlight.sztaki.hu:2222/rest";
+    public static final String DBPS_ADDRESS = "http://model.dbpedia-spotlight.org/en";
     private static final double DBPS_MIN_CONFIDENCE = 0.33;
 
     public DBpediaSpotlightAnnotate(Properties properties) {

--- a/pikes-twm/src/main/java/eu/fbk/dkm/pikes/twm/DBpediaSpotlightAnnotate.java
+++ b/pikes-twm/src/main/java/eu/fbk/dkm/pikes/twm/DBpediaSpotlightAnnotate.java
@@ -1,10 +1,7 @@
 package eu.fbk.dkm.pikes.twm;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import java.io.File;
 import java.util.*;
 
 /**
@@ -19,20 +16,24 @@ public class DBpediaSpotlightAnnotate extends Linking {
 
     private static String LABEL = "dbpedia-annotate";
     private String confidence;
+    private String allowedTypes;
     public static final String DBPS_ADDRESS = "http://spotlight.sztaki.hu:2222/rest";
     public static final double DBPS_MIN_CONFIDENCE = 0.33;
 
     public DBpediaSpotlightAnnotate(Properties properties) {
         super(properties, properties.getProperty("address", DBPS_ADDRESS) + "/annotate");
         confidence = properties.getProperty("min_confidence", Double.toString(DBPS_MIN_CONFIDENCE));
+        allowedTypes = properties.getProperty("types", null);
     }
 
     public List<LinkingTag> tag(String text) throws Exception {
-
         ArrayList<LinkingTag> ret = new ArrayList<>();
 
         Map<String, String> pars = new HashMap<>();
         pars.put("confidence", confidence);
+        if (allowedTypes != null) {
+            pars.put("types", allowedTypes);
+        }
         pars.put("text", text);
 
         Map<String, Object> userData;
@@ -67,16 +68,14 @@ public class DBpediaSpotlightAnnotate extends Linking {
 
     public static void main(String[] args) {
         Properties properties = new Properties();
-        properties.setProperty("address", "https://knowledgestore2.fbk.eu/dbps/rest/annotate");
-        properties.setProperty("use_proxy", "0");
-        properties.setProperty("proxy_url", "proxy.fbk.eu");
-        properties.setProperty("proxy_port", "3128");
+        properties.setProperty("address", "http://model.dbpedia-spotlight.org/en");
         properties.setProperty("min_confidence", "0.05");
+        properties.setProperty("types", "Drug,Disease,Chemical_compound");
         properties.setProperty("timeout", "2000");
 
         DBpediaSpotlightAnnotate s = new DBpediaSpotlightAnnotate(properties);
         try {
-            String text = Files.toString(new File("/Users/alessio/Desktop/elastic/test-dbps.txt"), Charsets.UTF_8);
+            String text = "My doctors suggests to me to take a pill of Aspirin.";
             List<LinkingTag> tags = s.tag(text);
             for (LinkingTag tag : tags) {
                 System.out.println(tag);

--- a/pikes-twm/src/main/java/eu/fbk/dkm/pikes/twm/DBpediaSpotlightAnnotate.java
+++ b/pikes-twm/src/main/java/eu/fbk/dkm/pikes/twm/DBpediaSpotlightAnnotate.java
@@ -4,21 +4,13 @@ import org.codehaus.jackson.map.ObjectMapper;
 
 import java.util.*;
 
-/**
- * Created with IntelliJ IDEA.
- * User: alessio
- * Date: 21/07/14
- * Time: 17:15
- * To change this template use File | Settings | File Templates.
- */
-
 public class DBpediaSpotlightAnnotate extends Linking {
 
     private static String LABEL = "dbpedia-annotate";
     private String confidence;
     private String allowedTypes;
-    public static final String DBPS_ADDRESS = "http://spotlight.sztaki.hu:2222/rest";
-    public static final double DBPS_MIN_CONFIDENCE = 0.33;
+    private static final String DBPS_ADDRESS = "http://spotlight.sztaki.hu:2222/rest";
+    private static final double DBPS_MIN_CONFIDENCE = 0.33;
 
     public DBpediaSpotlightAnnotate(Properties properties) {
         super(properties, properties.getProperty("address", DBPS_ADDRESS) + "/annotate");
@@ -75,7 +67,7 @@ public class DBpediaSpotlightAnnotate extends Linking {
 
         DBpediaSpotlightAnnotate s = new DBpediaSpotlightAnnotate(properties);
         try {
-            String text = "My doctors suggests to me to take a pill of Aspirin.";
+            String text = "My doctor has suggested to take a pill of Aspirin.";
             List<LinkingTag> tags = s.tag(text);
             for (LinkingTag tag : tags) {
                 System.out.println(tag);


### PR DESCRIPTION
Hi to all, 

I've noticed that you haven't considered the possibility to allow the user to specify type restrictions as it is reported in the official DBpedia Spotlight [documentation](https://github.com/dbpedia-spotlight/dbpedia-spotlight/wiki/User%27s-manual#example-2-with-type-restriction). For this reason, I've decided to contribute to this project by adding the *types* parameter to the HTTP request that is used to annotate the text using the DBpedia Spotlight service.

I hope that this pull request is appreciated.

Best regards,
Alessandro